### PR TITLE
Add Kindle HID Passthrough

### DIFF
--- a/KindleHIDPassthrough/install.sh
+++ b/KindleHIDPassthrough/install.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+set -e
+
+TMPDIR=/mnt/us/KFPM-Temporary
+INSTALL_DIR=/mnt/us/kindle_hid_passthrough
+RELEASE_URL="https://github.com/zampierilucas/kindle-hid-passthrough/releases/latest/download"
+
+mkdir -p "$TMPDIR"
+
+# ---- Download and extract release ----
+
+curl -fSL --progress-bar -o "$TMPDIR/release.tar.gz" \
+    "$RELEASE_URL/kindle-hid-passthrough-armv7.tar.gz"
+mkdir -p "$INSTALL_DIR"
+tar -xzf "$TMPDIR/release.tar.gz" -C "$INSTALL_DIR"
+
+# ---- Install system files (requires rw root) ----
+
+/usr/sbin/mntroot rw
+
+cp "$INSTALL_DIR/assets/hid-passthrough.upstart" /etc/upstart/hid-passthrough.conf
+cp "$INSTALL_DIR/assets/dev_is_keyboard.sh" /usr/local/bin/
+chmod +x /usr/local/bin/dev_is_keyboard.sh
+cp "$INSTALL_DIR/assets/99-hid-keyboard.rules" /etc/udev/rules.d/
+/usr/sbin/udevadm control --reload-rules
+
+/usr/sbin/mntroot ro || true
+
+# ---- Set permissions ----
+
+chmod +x "$INSTALL_DIR/kindle-hid-passthrough"
+chmod +x "$INSTALL_DIR/illusion/BTManager.sh"
+mkdir -p "$INSTALL_DIR/cache"
+
+# ---- Install scriptlet (registers WAF app on first launch) ----
+
+cp "$INSTALL_DIR/illusion/BTManager.sh" /mnt/us/documents/BTManager.sh
+chmod +x /mnt/us/documents/BTManager.sh
+
+# ---- Start daemon ----
+
+/sbin/initctl start hid-passthrough || true
+
+# ---- Cleanup ----
+
+rm -rf "$TMPDIR"
+
+exit 0

--- a/KindleHIDPassthrough/uninstall.sh
+++ b/KindleHIDPassthrough/uninstall.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -e
+
+INSTALL_DIR=/mnt/us/kindle_hid_passthrough
+APPREG_DB=/var/local/appreg.db
+APP_ID="com.lzampier.btmanager"
+
+# ---- Stop service ----
+
+/sbin/initctl stop hid-passthrough 2>/dev/null || true
+
+# ---- Remove system files ----
+
+/usr/sbin/mntroot rw
+
+rm -f /etc/upstart/hid-passthrough.conf
+rm -f /etc/udev/rules.d/99-hid-keyboard.rules
+rm -f /usr/local/bin/dev_is_keyboard.sh
+/usr/sbin/udevadm control --reload-rules 2>/dev/null || true
+
+/usr/sbin/mntroot ro || true
+
+# ---- Unregister WAF app ----
+
+if [ -f "$APPREG_DB" ]; then
+    sqlite3 "$APPREG_DB" <<EOF
+DELETE FROM properties WHERE handlerId='$APP_ID';
+DELETE FROM associations WHERE handlerId='$APP_ID';
+DELETE FROM handlerIds WHERE handlerId='$APP_ID';
+EOF
+fi
+
+# ---- Remove files ----
+
+rm -rf "$INSTALL_DIR"
+rm -f /mnt/us/documents/BTManager.sh
+
+exit 0

--- a/registry.json
+++ b/registry.json
@@ -222,5 +222,14 @@
         "ABI": ["hf", "sf"],
         "dependencies": [],
         "tags": ["UTILITY"]
+    },
+    {
+        "name": "Kindle HID Passthrough",
+        "uri": "KindleHIDPassthrough",
+        "description": "Bluetooth HID Passthrough (Keyboards, Mice, Controllers)",
+        "author": "Lucas Zampieri",
+        "ABI": ["hf", "sf"],
+        "dependencies": [],
+        "tags": ["UTILITY"]
     }
 ]


### PR DESCRIPTION
## Summary
- Bluetooth HID passthrough for Kindle (keyboards, mice, controllers, any HID device)
- Self-contained ARM binary (bundles own glibc/ld-linux, works on both hf and sf)
- Installs upstart service, udev rules, and BTManager WAF app for on-device management

## Links
- Project: https://github.com/zampierilucas/kindle-hid-passthrough