### PR TITLE
Wordgrinder added and Textadept updated

### DIFF
--- a/Textadept/install.sh
+++ b/Textadept/install.sh
@@ -6,8 +6,8 @@ TMPDIR=/mnt/us/KFPM-Temporary
 mkdir -p "$TMPDIR"
 
 # Download + Extract
-curl -fSL --progress-bar -o "$TMPDIR/wordgrinder.zip" https://github.com/kbarni/wordgrinder/releases/latest/download/wordgrinder.zip
-unzip -q "$TMPDIR/wordgrinder.zip" -d /mnt/us
+curl -fSL --progress-bar -o "$TMPDIR/textadept.zip" https://github.com/kbarni/textadept-kindle/releases/latest/download/textadept.zip
+unzip -q "$TMPDIR/textadept.zip" -d /mnt/us
 
 # Cleanup
 rm -rf "$TMPDIR"

--- a/Textadept/install.sh
+++ b/Textadept/install.sh
@@ -6,8 +6,8 @@ TMPDIR=/mnt/us/KFPM-Temporary
 mkdir -p "$TMPDIR"
 
 # Download + Extract
-curl -fSL --progress-bar -o "$TMPDIR/textadept.zip" https://github.com/kbarni/textadept-kindle/releases/latest/download/textadept_gtk+term.zip
-unzip -q "$TMPDIR/textadept.zip" -d /mnt/us
+curl -fSL --progress-bar -o "$TMPDIR/wordgrinder.zip" https://github.com/kbarni/wordgrinder/releases/latest/download/wordgrinder.zip
+unzip -q "$TMPDIR/wordgrinder.zip" -d /mnt/us
 
 # Cleanup
 rm -rf "$TMPDIR"

--- a/Textadept/uninstall.sh
+++ b/Textadept/uninstall.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-rm -rf /mnt/us/textadept11
+rm -rf /mnt/us/textadept
 rm -rf /mnt/us/extensions/textadept
+rm /mnt/us/documents/textadept.sh
 
 exit 0

--- a/Wordgrinder/install.sh
+++ b/Wordgrinder/install.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+TMPDIR=/mnt/us/KFPM-Temporary
+mkdir -p "$TMPDIR"
+
+# Download + Extract
+curl -fSL --progress-bar -o "$TMPDIR/textadept.zip" https://github.com/kbarni/textadept-kindle/releases/latest/download/textadept.zip
+unzip -q "$TMPDIR/textadept.zip" -d /mnt/us
+
+# Cleanup
+rm -rf "$TMPDIR"
+
+exit 0

--- a/Wordgrinder/install.sh
+++ b/Wordgrinder/install.sh
@@ -6,8 +6,8 @@ TMPDIR=/mnt/us/KFPM-Temporary
 mkdir -p "$TMPDIR"
 
 # Download + Extract
-curl -fSL --progress-bar -o "$TMPDIR/textadept.zip" https://github.com/kbarni/textadept-kindle/releases/latest/download/textadept.zip
-unzip -q "$TMPDIR/textadept.zip" -d /mnt/us
+curl -fSL --progress-bar -o "$TMPDIR/wordgrinder.zip" https://github.com/kbarni/wordgrinder/releases/latest/download/wordgrinder.zip
+unzip -q "$TMPDIR/wordgrinder.zip" -d /mnt/us
 
 # Cleanup
 rm -rf "$TMPDIR"

--- a/Wordgrinder/uninstall.sh
+++ b/Wordgrinder/uninstall.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+rm -rf /mnt/us/textadept11
+rm -rf /mnt/us/extensions/textadept
+
+exit 0

--- a/Wordgrinder/uninstall.sh
+++ b/Wordgrinder/uninstall.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-rm -rf /mnt/us/textadept11
-rm -rf /mnt/us/extensions/textadept
+rm -rf /mnt/us/wordgrinder
+rm /mnt/us/documents/wordgrinder.sh
 
 exit 0

--- a/registry.json
+++ b/registry.json
@@ -210,9 +210,18 @@
         "uri": "Textadept",
         "description": "A Desktop-Grade Text Editor For Kindle",
         "author": "Barna",
-        "ABI": ["hf"],
+        "ABI": ["hf", "sf"],
         "dependencies": ["kTerm"],
-        "tags": ["DEVELOPMENT", "PRODUCTIVITY"]
+        "tags": ["DEVELOPMENT", "PRODUCTIVITY", "EDITORS"]
+    },
+    {
+        "name": "Wordgrinder",
+        "uri": "Wordgrinder",
+        "description": "The Writer's Word Processor",
+        "author": "Barna",
+        "ABI": ["hf", "sf"],
+        "dependencies": ["kTerm"],
+        "tags": ["PRODUCTIVITY", "EDITORS"]
     },
     {
         "name": "KUAL",

--- a/registry.json
+++ b/registry.json
@@ -181,7 +181,7 @@
     {
         "name": "LARKPlayer",
         "uri": "LARKPlayer",
-        "description": "LARK Is a M4B Audiobook Reader for Kindles",
+        "description": "LARK Is a Free Audiobook Reader for Kindles",
         "author": "Barna",
         "ABI": ["hf"],
         "dependencies": [],
@@ -211,7 +211,7 @@
         "description": "A Desktop-Grade Text Editor For Kindle",
         "author": "Barna",
         "ABI": ["hf", "sf"],
-        "dependencies": ["kTerm"],
+        "dependencies": ["kTerm","KindleHIDPassthrough"],
         "tags": ["DEVELOPMENT", "PRODUCTIVITY", "EDITORS"]
     },
     {
@@ -220,7 +220,7 @@
         "description": "The Writer's Word Processor",
         "author": "Barna",
         "ABI": ["hf", "sf"],
-        "dependencies": ["kTerm"],
+        "dependencies": ["kTerm","KindleHIDPassthrough"],
         "tags": ["PRODUCTIVITY", "EDITORS"]
     },
     {


### PR DESCRIPTION
To "celebrate" the release of *Bluetooth HID passthrough*, I made some contributions to the text editors.

First, I updated [Textadept](https://github.com/orbitalquark/textadept) ([Homepage](https://orbitalquark.github.io/textadept/)) to the latest release (12.9) with a several of optimizations to the Kindle.

I also ported [Wordgrinder](https://github.com/davidgiven/wordgrinder) ([Homepage](https://cowlark.com/wordgrinder/)), which is a simple but effective word processor for writers, that works also well on the Kindle. 

Normally both should work on HF and PW2 architectures.