### PR TITLE
Add Kindle Series Manager package

### DIFF
--- a/KindleSeriesManager/install.sh
+++ b/KindleSeriesManager/install.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -e
+
+TMPDIR=/mnt/us/KFPM-Temporary
+mkdir -p "$TMPDIR"
+
+REPO="mlapaglia/kindle-series-manager"
+ASSET="kindle-series-manager"
+
+LATEST_TAG=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+
+if [ -z "$LATEST_TAG" ]; then
+    exit 1
+fi
+
+curl -fSL --progress-bar "https://github.com/$REPO/releases/download/$LATEST_TAG/$ASSET-$LATEST_TAG.zip" -o "$TMPDIR/ksm.zip"
+
+unzip -o "$TMPDIR/ksm.zip" "kual-extension/*" -d "$TMPDIR"
+
+mkdir -p /mnt/us/extensions
+cp -r "$TMPDIR/kual-extension/kindle-series-manager" /mnt/us/extensions/
+
+chmod +x /mnt/us/extensions/kindle-series-manager/bin/*.sh 2>/dev/null
+chmod +x /mnt/us/extensions/kindle-series-manager/bin/busybox-httpd 2>/dev/null
+chmod +x /mnt/us/extensions/kindle-series-manager/www/cgi-bin/*.cgi 2>/dev/null
+
+rm -rf "$TMPDIR"
+
+exit 0

--- a/KindleSeriesManager/uninstall.sh
+++ b/KindleSeriesManager/uninstall.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+EXT_DIR="/mnt/us/extensions/kindle-series-manager"
+
+# Stop the web server
+HTTPD_PID="/tmp/kindle_series_manager_httpd.pid"
+if [ -f "$HTTPD_PID" ]; then
+    kill "$(cat "$HTTPD_PID")" 2>/dev/null
+    rm -f "$HTTPD_PID"
+fi
+killall busybox-httpd 2>/dev/null
+iptables -D INPUT -p tcp --dport 8080 -j ACCEPT 2>/dev/null
+
+# Stop FBInk screensaver daemon and restore stock screensaver
+SS_PID="/tmp/fbink_ss_daemon.pid"
+if [ -f "$SS_PID" ]; then
+    kill "$(cat "$SS_PID")" 2>/dev/null
+    rm -f "$SS_PID"
+fi
+rm -f /tmp/fbink_ss_events.fifo /tmp/fbink_ss_last
+start pillow 2>/dev/null
+lipc-set-prop com.lab126.blanket load screensaver 2>/dev/null
+
+# Stop Goodreads sync daemon and remove upstart job
+stop gr-sync 2>/dev/null
+rm -f /mnt/us/ENABLE_GR_SYNC
+mntroot rw 2>/dev/null
+rm -f /etc/upstart/gr-sync.conf
+
+# Clean up Goodreads event FIFO
+rm -f "$EXT_DIR/goodreads/gr_events.fifo"
+
+# Remove disabled screensavers folder if empty
+rmdir /mnt/us/screensaver_disabled 2>/dev/null
+
+# Remove the extension
+rm -rf "$EXT_DIR"
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Current packages (22):
 - KinAMP
 - KindleCraft
 - KindleFetch
+- Kindle Series Manager
 - KNotes
 - KOReader
 - KPM

--- a/registry.json
+++ b/registry.json
@@ -238,7 +238,7 @@
         "description": "Group sideloaded books into series, custom screensavers, Goodreads sync, wireless book uploads",
         "author": "mlapaglia",
         "ABI": ["hf", "sf"],
-        "dependencies": ["KUAL"],
+        "dependencies": [],
         "tags": ["UTILITY", "PRODUCTIVITY"]
     }
 ]

--- a/registry.json
+++ b/registry.json
@@ -231,5 +231,14 @@
         "ABI": ["hf", "sf"],
         "dependencies": [],
         "tags": ["UTILITY"]
+    },
+    {
+        "name": "Kindle Series Manager",
+        "uri": "KindleSeriesManager",
+        "description": "Group sideloaded books into series, custom screensavers, Goodreads sync, wireless book uploads",
+        "author": "mlapaglia",
+        "ABI": ["hf", "sf"],
+        "dependencies": ["KUAL"],
+        "tags": ["UTILITY", "PRODUCTIVITY"]
     }
 ]


### PR DESCRIPTION
## Summary

Adds [Kindle Series Manager](https://github.com/mlapaglia/kindle-series-manager) to the KindleForge repository.

**What it does:**
- Group sideloaded books into series (same as Amazon's store-bought series grouping)
- Custom screensavers with FBInk-based rendering (safer than stock, won't brick on malformed images)
- Goodreads reading progress sync
- Wireless book uploads via web UI
- Database backup/restore

**Package details:**
- Install downloads the latest GitHub release and extracts the KUAL extension to \/mnt/us/extensions/
- Uninstall cleanly stops all running services (web server, screensaver daemon, Goodreads sync), removes the upstart job, cleans up flag files and temp files, restores stock screensaver, and removes the extension
- Pure shell scripts + bundled static busybox httpd binary, works on both hf and sf devices
- Web UI served from the Kindle itself, accessed from phone/PC on the same WiFi network

**Links:**
- Repo: https://github.com/mlapaglia/kindle-series-manager
- Docs: https://kindle-series-manager.readthedocs.io/en/latest/