### PR TITLE
KindleHIDPassthrough: install KOReader plugin when KOReader is present

### DIFF
--- a/KindleHIDPassthrough/install.sh
+++ b/KindleHIDPassthrough/install.sh
@@ -38,6 +38,14 @@ mkdir -p "$INSTALL_DIR/cache"
 cp "$INSTALL_DIR/illusion/BTManager.sh" /mnt/us/documents/BTManager.sh
 chmod +x /mnt/us/documents/BTManager.sh
 
+# ---- Install KOReader plugin (if KOReader is installed) ----
+
+if [ -d /mnt/us/koreader/plugins/ ] && [ -d "$INSTALL_DIR/koreader-plugin/hidpassthrough.koplugin" ]; then
+    mkdir -p /mnt/us/koreader/plugins/hidpassthrough.koplugin
+    cp -r "$INSTALL_DIR/koreader-plugin/hidpassthrough.koplugin/." \
+        /mnt/us/koreader/plugins/hidpassthrough.koplugin/
+fi
+
 # ---- Start daemon ----
 
 /sbin/initctl start hid-passthrough || true

--- a/KindleHIDPassthrough/uninstall.sh
+++ b/KindleHIDPassthrough/uninstall.sh
@@ -31,6 +31,10 @@ DELETE FROM handlerIds WHERE handlerId='$APP_ID';
 EOF
 fi
 
+# ---- Remove KOReader plugin (if installed) ----
+
+rm -rf /mnt/us/koreader/plugins/hidpassthrough.koplugin
+
 # ---- Remove files ----
 
 rm -rf "$INSTALL_DIR"


### PR DESCRIPTION
## Summary

The kindle-hid-passthrough now ships a `koreader-plugin/` directory as of [v3.4.0](https://github.com/zampierilucas/kindle-hid-passthrough/pull/42). When `/mnt/us/koreader/plugins/` exists, copy `koreader-plugin/hidpassthrough.koplugin/` into it so users get the in-KOReader manager (scan / pair / connect / disconnect / logs / cache) without an extra install step. Skipped silently when KOReader isn't installed.

`uninstall.sh` mirrors the install: removes the plugin directory.