### PR TITLE
KindleHIDPassthrough: stop copying dev_is_keyboard.sh to /usr/local/bin

### DIFF
--- a/KindleHIDPassthrough/install.sh
+++ b/KindleHIDPassthrough/install.sh
@@ -20,8 +20,6 @@ tar -xzf "$TMPDIR/release.tar.gz" -C "$INSTALL_DIR"
 /usr/sbin/mntroot rw
 
 cp "$INSTALL_DIR/assets/hid-passthrough.upstart" /etc/upstart/hid-passthrough.conf
-cp "$INSTALL_DIR/assets/dev_is_keyboard.sh" /usr/local/bin/
-chmod +x /usr/local/bin/dev_is_keyboard.sh
 cp "$INSTALL_DIR/assets/99-hid-keyboard.rules" /etc/udev/rules.d/
 /usr/sbin/udevadm control --reload-rules
 

--- a/KindleHIDPassthrough/uninstall.sh
+++ b/KindleHIDPassthrough/uninstall.sh
@@ -16,7 +16,7 @@ APP_ID="com.lzampier.btmanager"
 
 rm -f /etc/upstart/hid-passthrough.conf
 rm -f /etc/udev/rules.d/99-hid-keyboard.rules
-rm -f /usr/local/bin/dev_is_keyboard.sh
+[ -f /usr/local/bin/dev_is_keyboard.sh ] && rm -f /usr/local/bin/dev_is_keyboard.sh
 /usr/sbin/udevadm control --reload-rules 2>/dev/null || true
 
 /usr/sbin/mntroot ro || true


### PR DESCRIPTION
This is the second, and hopefully last, cleanup of the usage of /usr/local/bin for kindle-hid-passthrough.

- Drop the `cp $INSTALL_DIR/assets/dev_is_keyboard.sh /usr/local/bin/` + `chmod +x` from `KindleHIDPassthrough/install.sh`.
- Guard the matching `rm` in `uninstall.sh` with `[ -f ]` so old installs still get cleaned up