### PR TITLE
Add Kindle Button Mapper

### DIFF
--- a/KindleButtonMapper/install.sh
+++ b/KindleButtonMapper/install.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -e
+
+TMPDIR=/mnt/us/KFPM-Temporary
+INSTALL_DIR=/mnt/us/kindle-button-mapper
+RELEASE_URL="https://github.com/zampierilucas/kindle-button-mapper-rs/releases/latest/download"
+
+mkdir -p "$TMPDIR" "$INSTALL_DIR"
+
+curl -fSL --progress-bar -o "$TMPDIR/release.tar.gz" \
+    "$RELEASE_URL/kindle-button-mapper-armv7.tar.gz"
+tar -xzf "$TMPDIR/release.tar.gz" -C "$INSTALL_DIR"
+
+chmod +x "$INSTALL_DIR/kindle-button-mapper"
+chmod +x "$INSTALL_DIR/scripts/"*.sh 2>/dev/null || true
+chmod +x "$INSTALL_DIR/illusion/"*.sh 2>/dev/null || true
+
+/usr/sbin/mntroot rw
+
+cp "$INSTALL_DIR/kindle-button-mapper.init" /etc/init.d/kindle-button-mapper
+chmod +x /etc/init.d/kindle-button-mapper
+
+cp "$INSTALL_DIR/illusion/MapperManager.sh" /mnt/us/documents/MapperManager.sh
+chmod +x /mnt/us/documents/MapperManager.sh
+
+sh "$INSTALL_DIR/illusion/install-waf-app.sh" || true
+
+/usr/sbin/mntroot ro || true
+
+/etc/init.d/kindle-button-mapper start || true
+
+rm -rf "$TMPDIR"
+
+exit 0

--- a/KindleButtonMapper/uninstall.sh
+++ b/KindleButtonMapper/uninstall.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+INSTALL_DIR=/mnt/us/kindle-button-mapper
+APPREG_DB=/var/local/appreg.db
+APP_ID="com.lzampier.mappermanager"
+
+/etc/init.d/kindle-button-mapper stop 2>/dev/null || true
+
+/usr/sbin/mntroot rw
+
+rm -f /etc/init.d/kindle-button-mapper
+
+if [ -f "$APPREG_DB" ]; then
+    sqlite3 "$APPREG_DB" <<EOF
+DELETE FROM properties WHERE handlerId='$APP_ID';
+DELETE FROM associations WHERE handlerId='$APP_ID';
+DELETE FROM handlerIds WHERE handlerId='$APP_ID';
+EOF
+fi
+
+/usr/sbin/mntroot ro || true
+
+rm -rf "$INSTALL_DIR"
+rm -f /mnt/us/documents/MapperManager.sh
+
+exit 0

--- a/registry.json
+++ b/registry.json
@@ -244,7 +244,7 @@
     {
         "name": "Kindle Button Mapper",
         "uri": "KindleButtonMapper",
-        "description": "Map Controller and Keyboard Buttons to Custom Scripts",
+        "description": "Map Controller and Keyboard Buttons to Any Key or Script",
         "author": "Lucas Zampieri",
         "ABI": ["hf", "sf"],
         "dependencies": [],

--- a/registry.json
+++ b/registry.json
@@ -240,5 +240,14 @@
         "ABI": ["hf", "sf"],
         "dependencies": [],
         "tags": ["UTILITY"]
+    },
+    {
+        "name": "Kindle Button Mapper",
+        "uri": "KindleButtonMapper",
+        "description": "Map Controller and Keyboard Buttons to Reader Actions",
+        "author": "Lucas Zampieri",
+        "ABI": ["hf", "sf"],
+        "dependencies": [],
+        "tags": ["UTILITY"]
     }
 ]

--- a/registry.json
+++ b/registry.json
@@ -244,7 +244,7 @@
     {
         "name": "Kindle Button Mapper",
         "uri": "KindleButtonMapper",
-        "description": "Map Controller and Keyboard Buttons to Reader Actions",
+        "description": "Map Controller and Keyboard Buttons to Custom Scripts",
         "author": "Lucas Zampieri",
         "ABI": ["hf", "sf"],
         "dependencies": [],


### PR DESCRIPTION
Adds **Kindle Button Mapper** to the registry.

Remaps `/dev/input` button events from controllers and keyboards to **any keystroke** (via an on-device virtual keyboard) or **any shell script** — page turns, brightness, launching apps, injecting keys to other programs, or anything else the user wires up in `config.ini`. Static armv7 `musl` binary, includes an on-device WAF config app (*MapperManager*) for editing mappings without SSH.

- Source: https://github.com/zampierilucas/kindle-button-mapper-rs
- `install.sh` pulls `kindle-button-mapper-armv7.tar.gz` from the project's GitHub releases, installs the init script, registers the WAF app, and starts the daemon.
- `uninstall.sh` stops the daemon, unregisters the WAF app, and removes installed files.
- ABI: `hf` + `sf` (tested working on a soft-float Kindle).
- No dependencies.