### PR TITLE
KindleButtonMapper: bootstrap install from upstream repo

### DIFF
--- a/KindleButtonMapper/install.sh
+++ b/KindleButtonMapper/install.sh
@@ -2,34 +2,6 @@
 
 set -e
 
-TMPDIR=/mnt/us/KFPM-Temporary
-INSTALL_DIR=/mnt/us/kindle-button-mapper
-RELEASE_URL="https://github.com/zampierilucas/kindle-button-mapper-rs/releases/latest/download"
-
-mkdir -p "$TMPDIR" "$INSTALL_DIR"
-
-curl -fSL --progress-bar -o "$TMPDIR/release.tar.gz" \
-    "$RELEASE_URL/kindle-button-mapper-armv7.tar.gz"
-tar -xzf "$TMPDIR/release.tar.gz" -C "$INSTALL_DIR"
-
-chmod +x "$INSTALL_DIR/kindle-button-mapper"
-chmod +x "$INSTALL_DIR/scripts/"*.sh 2>/dev/null || true
-chmod +x "$INSTALL_DIR/illusion/"*.sh 2>/dev/null || true
-
-/usr/sbin/mntroot rw
-
-cp "$INSTALL_DIR/kindle-button-mapper.init" /etc/init.d/kindle-button-mapper
-chmod +x /etc/init.d/kindle-button-mapper
-
-cp "$INSTALL_DIR/illusion/MapperManager.sh" /mnt/us/documents/MapperManager.sh
-chmod +x /mnt/us/documents/MapperManager.sh
-
-sh "$INSTALL_DIR/illusion/install-waf-app.sh" || true
-
-/usr/sbin/mntroot ro || true
-
-/etc/init.d/kindle-button-mapper start || true
-
-rm -rf "$TMPDIR"
+sh -c "$(curl -fSL --progress-bar https://raw.githubusercontent.com/zampierilucas/kindle-button-mapper-rs/master/docs/kindleforge/install.sh)"
 
 exit 0

--- a/KindleButtonMapper/uninstall.sh
+++ b/KindleButtonMapper/uninstall.sh
@@ -2,27 +2,6 @@
 
 set -e
 
-INSTALL_DIR=/mnt/us/kindle-button-mapper
-APPREG_DB=/var/local/appreg.db
-APP_ID="com.lzampier.mappermanager"
-
-/etc/init.d/kindle-button-mapper stop 2>/dev/null || true
-
-/usr/sbin/mntroot rw
-
-rm -f /etc/init.d/kindle-button-mapper
-
-if [ -f "$APPREG_DB" ]; then
-    sqlite3 "$APPREG_DB" <<EOF
-DELETE FROM properties WHERE handlerId='$APP_ID';
-DELETE FROM associations WHERE handlerId='$APP_ID';
-DELETE FROM handlerIds WHERE handlerId='$APP_ID';
-EOF
-fi
-
-/usr/sbin/mntroot ro || true
-
-rm -rf "$INSTALL_DIR"
-rm -f /mnt/us/documents/MapperManager.sh
+sh -c "$(curl -fSL --progress-bar https://raw.githubusercontent.com/zampierilucas/kindle-button-mapper-rs/master/docs/kindleforge/uninstall.sh)"
 
 exit 0


### PR DESCRIPTION
Replaces `KindleButtonMapper/install.sh` + `uninstall.sh` with thin bootstraps that fetch and run `docs/kindleforge/{install,uninstall}.sh` from the project repo. After this, install-logic changes ship from the upstream repo without another KindleForge PR.

First real payload it delivers: switching the daemon from a SysV `/etc/init.d` script to an `/etc/upstart` job so it autostarts on boot (it currently dies on every reboot).