### PR TITLE
KindleHIDPassthrough: stop the daemon before unpacking, delegate to install.sh

### DIFF
--- a/KindleHIDPassthrough/install.sh
+++ b/KindleHIDPassthrough/install.sh
@@ -6,50 +6,21 @@ TMPDIR=/mnt/us/KFPM-Temporary
 INSTALL_DIR=/mnt/us/kindle_hid_passthrough
 RELEASE_URL="https://github.com/zampierilucas/kindle-hid-passthrough/releases/latest/download"
 
-mkdir -p "$TMPDIR"
+# The running daemon keeps dist/ld-linux-armhf.so.3 busy, and busybox tar stops
+# at the first entry it cannot replace, so stop it before unpacking.
+/sbin/stop hid-passthrough 2>/dev/null || true
+pkill -f "kindle-hid-passthrough" 2>/dev/null || true
+pkill -f "ld-linux-armhf." 2>/dev/null || true
+sleep 2
 
-# ---- Download and extract release ----
+mkdir -p "$TMPDIR" "$INSTALL_DIR"
 
 curl -fSL --progress-bar -o "$TMPDIR/release.tar.gz" \
     "$RELEASE_URL/kindle-hid-passthrough-armv7.tar.gz"
-mkdir -p "$INSTALL_DIR"
 tar -xzf "$TMPDIR/release.tar.gz" -C "$INSTALL_DIR"
 
-# ---- Install system files (requires rw root) ----
-
-/usr/sbin/mntroot rw
-
-cp "$INSTALL_DIR/assets/hid-passthrough.upstart" /etc/upstart/hid-passthrough.conf
-cp "$INSTALL_DIR/assets/99-hid-keyboard.rules" /etc/udev/rules.d/
-/usr/sbin/udevadm control --reload-rules
-
-/usr/sbin/mntroot ro || true
-
-# ---- Set permissions ----
-
-chmod +x "$INSTALL_DIR/kindle-hid-passthrough"
-chmod +x "$INSTALL_DIR/illusion/BTManager.sh"
-mkdir -p "$INSTALL_DIR/cache"
-
-# ---- Install scriptlet (registers WAF app on first launch) ----
-
-cp "$INSTALL_DIR/illusion/BTManager.sh" /mnt/us/documents/BTManager.sh
-chmod +x /mnt/us/documents/BTManager.sh
-
-# ---- Install KOReader plugin (if KOReader is installed) ----
-
-if [ -d /mnt/us/koreader/plugins/ ] && [ -d "$INSTALL_DIR/koreader-plugin/hidpassthrough.koplugin" ]; then
-    mkdir -p /mnt/us/koreader/plugins/hidpassthrough.koplugin
-    cp -r "$INSTALL_DIR/koreader-plugin/hidpassthrough.koplugin/." \
-        /mnt/us/koreader/plugins/hidpassthrough.koplugin/
-fi
-
-# ---- Start daemon ----
-
-/sbin/initctl start hid-passthrough || true
-
-# ---- Cleanup ----
-
 rm -rf "$TMPDIR"
+
+sh "$INSTALL_DIR/scripts/install.sh" installAll
 
 exit 0

--- a/KindleHIDPassthrough/uninstall.sh
+++ b/KindleHIDPassthrough/uninstall.sh
@@ -3,41 +3,20 @@
 set -e
 
 INSTALL_DIR=/mnt/us/kindle_hid_passthrough
-APPREG_DB=/var/local/appreg.db
-APP_ID="com.lzampier.btmanager"
 
-# ---- Stop service ----
-
-/sbin/initctl stop hid-passthrough 2>/dev/null || true
-
-# ---- Remove system files ----
-
-/usr/sbin/mntroot rw
-
-rm -f /etc/upstart/hid-passthrough.conf
-rm -f /etc/udev/rules.d/99-hid-keyboard.rules
-[ -f /usr/local/bin/dev_is_keyboard.sh ] && rm -f /usr/local/bin/dev_is_keyboard.sh
-/usr/sbin/udevadm control --reload-rules 2>/dev/null || true
-
-/usr/sbin/mntroot ro || true
-
-# ---- Unregister WAF app ----
-
-if [ -f "$APPREG_DB" ]; then
-    sqlite3 "$APPREG_DB" <<EOF
-DELETE FROM properties WHERE handlerId='$APP_ID';
-DELETE FROM associations WHERE handlerId='$APP_ID';
-DELETE FROM handlerIds WHERE handlerId='$APP_ID';
-EOF
+if [ -f "$INSTALL_DIR/scripts/install.sh" ]; then
+    sh "$INSTALL_DIR/scripts/install.sh" uninstallAll
+else
+    # Nothing to delegate to, clear out what the install would have left.
+    /sbin/stop hid-passthrough 2>/dev/null || true
+    /usr/sbin/mntroot rw
+    rm -f /etc/upstart/hid-passthrough.conf
+    rm -f /etc/udev/rules.d/99-hid-keyboard.rules
+    [ -f /usr/local/bin/dev_is_keyboard.sh ] && rm -f /usr/local/bin/dev_is_keyboard.sh
+    /usr/sbin/udevadm control --reload-rules 2>/dev/null || true
+    /usr/sbin/mntroot ro || true
+    rm -rf "$INSTALL_DIR" /mnt/us/koreader/plugins/hidpassthrough.koplugin
+    rm -f /mnt/us/documents/BTManager.sh
 fi
-
-# ---- Remove KOReader plugin (if installed) ----
-
-rm -rf /mnt/us/koreader/plugins/hidpassthrough.koplugin
-
-# ---- Remove files ----
-
-rm -rf "$INSTALL_DIR"
-rm -f /mnt/us/documents/BTManager.sh
 
 exit 0


### PR DESCRIPTION
Installing over a live install landed a partial tree. The daemon holds `dist/ld-linux-armhf.so.3` open so writes come back ETXTBSY, busybox tar stops at the first entry it cannot replace, and that file is entry 8 of 120. The extract wrote six `.so` files, then `set -e` ended the script before upstart, udev, the scriptlet and the plugin were installed, with KFPM still showing success. Reproduced on a Basic 5.

So it stops the daemon before unpacking, and hands the rest to `scripts/install.sh installAll` rather than duplicating it here, which also picks up stale file removal, `config.ini` preservation and the mesquite cache clear. Uninstall delegates the same way, with a fallback for when the install dir is already gone.

Safe to merge before the upstream release. v3.12.0 already runs its installer from the install dir, and the daemon stop fixes the partial tree on its own. Upstream change is zampierilucas/kindle-hid-passthrough#149.