### PR TITLE
Quran: read the Qur'an in Arabic and English, offline

### DIFF
--- a/Quran/install.sh
+++ b/Quran/install.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# KindleForge installer for the Qur'an plugin.
+#
+# The payload is NOT stored in the KindleForge repository -- that is the
+# convention there (kTerm, KPomo and KOReader all fetch from upstream; only
+# tiny script-only packages keep files in assets/). It lives in this project's
+# own GitHub releases, and is fetched from the version-free
+# /releases/latest/download/ URL so that every future release is picked up
+# without another pull request against the package index.
+#
+# Requires KOReader, which is declared as a dependency in registry.json --
+# this plugin renders nothing on its own.
+
+set -e
+
+TMPDIR=/mnt/us/KFPM-Temporary
+PACKAGE="https://github.com/alfajrd/kindle-quran/releases/latest/download/quran.tar.gz"
+
+mkdir -p "$TMPDIR"
+
+# Fail early and loudly if KOReader is not there. The dependency is declared,
+# but a manual install or a half-removed KOReader would otherwise leave the
+# plugin unpacked into a directory nothing reads, which looks like a silent
+# success and is the worst outcome available here.
+if [ ! -d /mnt/us/koreader ]; then
+  echo "Qur'an: /mnt/us/koreader not found -- install KOReader first." 1>&2
+  rm -rf "$TMPDIR"
+  exit 1
+fi
+
+# Download.
+curl -fSL --progress-bar -o "$TMPDIR/quran.tar.gz" "$PACKAGE"
+
+# The archive is laid out to extract straight into /mnt/us with no path
+# rewriting: koreader/plugins/quran.koplugin, koreader/fonts and
+# extensions/quran. Building it that way is what keeps this script short
+# enough to audit -- see tools/make_release.py in the source repository.
+tar -xf "$TMPDIR/quran.tar.gz" -C /mnt/us/
+
+chmod +x /mnt/us/extensions/quran/bin/quran.sh
+
+# Cleanup.
+rm -rf "$TMPDIR"
+
+exit 0

--- a/Quran/uninstall.sh
+++ b/Quran/uninstall.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# KindleForge uninstaller for the Qur'an plugin.
+#
+# Removes what install.sh put there, and nothing else.
+#
+# DELIBERATELY LEFT BEHIND:
+#
+#   <koreader>/settings/quran.lua              reading position, bookmarks,
+#                                              typography
+#   <koreader>/settings/quran-translation.db   a translation the reader
+#                                              side-loaded themselves
+#
+# Both are the reader's own data, not ours. Someone uninstalling to reinstall a
+# newer build should not silently lose where they had got to, or a translation
+# file they put there by hand. Anyone who genuinely wants them gone can delete
+# two files; nobody can undo an uninstall that deleted them.
+#
+# The bundled Pickthall pack DOES go: it lives inside quran.koplugin/data/ and
+# is ours to remove.
+
+set -e
+
+rm -rf /mnt/us/koreader/plugins/quran.koplugin
+rm -rf /mnt/us/extensions/quran
+rm -f /mnt/us/koreader/fonts/ScheherazadeNew-Regular.ttf
+rm -f /mnt/us/koreader/fonts/ScheherazadeNew-OFL.txt
+
+exit 0

--- a/registry.json
+++ b/registry.json
@@ -249,5 +249,14 @@
         "ABI": ["hf", "sf"],
         "dependencies": [],
         "tags": ["UTILITY"]
+    },
+    {
+        "name": "Qur'an",
+        "uri": "Quran",
+        "description": "Read The Quran In Arabic And English, Offline",
+        "author": "alfajrd",
+        "ABI": ["hf", "sf"],
+        "dependencies": ["KOReader"],
+        "tags": ["MEDIA"]
     }
 ]


### PR DESCRIPTION
A KOReader plugin for reading the Qur'an on a jailbroken Kindle: Uthmani Arabic beside an English translation, in a two-column layout, entirely offline. Surah/juz navigation, reference jump (`2:255`), bookmarks, and independent typography for each script. Hold a word in the translation column to look it up in KOReader's dictionary.

- **Source:** https://github.com/alfajrd/kindle-quran
- **Release:** https://github.com/alfajrd/kindle-quran/releases/tag/v1.0.0
- **Depends on:** KOReader (already in the index)
- **Size:** ~1.0 MB compressed — mostly the two SQLite packs and the Arabic font

## Packaging notes

`install.sh` fetches the payload from the project's own releases, following the convention kTerm, KPomo and KOReader use here rather than putting an application payload in `assets/`. It uses the version-free `/releases/latest/download/quran.tar.gz` URL, so **future versions should not need another PR against this repo** — only a change to the install layout or dependencies would.

The archive is laid out to extract straight into `/mnt/us` with no path rewriting, which is what keeps the installer short enough to read. It is also built reproducibly (fixed mtimes, ownership and gzip headers), so the published `sha256` can be checked against a rebuild from source:

```
c73422f8f189b48ae217464841be100cab4bc7dd3f2ea1dbff275d816b9ca285  quran-1.0.0.tar.gz
```

`install.sh` checks for `/mnt/us/koreader` and exits with a message if it is absent, rather than trusting the declared dependency — unpacking a KOReader plugin where no KOReader will read it looks like success and isn't.

`uninstall.sh` removes everything the installer wrote, and deliberately leaves the reader's saved position, bookmarks and any translation they side-loaded themselves. Those are the user's own data, and someone uninstalling to reinstall a newer build shouldn't silently lose where they had got to.

## Testing

**Tested on a Paperwhite 11 (hf).** The plugin is pure Lua and ships no compiled code, so it has no ABI constraint of its own and I've listed both — but `sf` is untested, and I'd rather say so than have you find out. Happy to narrow it to `["hf"]` if you'd prefer packages claim only what's been run.

`tags` is `["MEDIA"]` — there's no religion or reference tag in the index, and that seemed the closest single fit alongside KindleFetch. Glad to change it.

## Licensing

Everything redistributed is either public domain or under a licence that permits it, and each item is recorded in [THIRD-PARTY.md](https://github.com/alfajrd/kindle-quran/blob/main/THIRD-PARTY.md), which also ships inside the plugin directory:

| Item | Terms |
|---|---|
| Qur'anic text (Uthmani) | [Tanzil.net](https://tanzil.net), CC BY 3.0 — redistributed verbatim, byte-pinned by SHA-256, with attribution |
| English translation | Marmaduke Pickthall (1930) — **public domain**: the US term expired 1 January 2026, life+70 expired 2006 |
| Scheherazade New | SIL OFL 1.1 — the licence is bundled alongside the font, as OFL requires |

No translation still under copyright is included. Thanks for maintaining the index.
